### PR TITLE
respond to the host and port the query originated from

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ DNSDiscovery.prototype._onmulticastquery = function (query, port, host) {
 
   if (reply.answers.length) {
     this.emit('traffic', 'out:multicastresponse', {message: reply})
-    this.multicast.response(reply)
+    this.multicast.response(reply, {host: host, port: port})
   }
 }
 


### PR DESCRIPTION
If you get a query from a process bound to a non-standard port we reply to 5353 and the message is lost.   This has us reply to the host/port we got the message originated from.