### PR TITLE
Avoid CVE-2021-23386

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "circular-append-file": "^1.0.1",
     "debug": "^2.6.9",
-    "dns-socket": "^3.0.0",
+    "dns-socket": "^4.2.2",
     "lru": "^2.0.0",
     "minimist": "^1.2.0",
     "multicast-dns": "^7.1.1",


### PR DESCRIPTION
Update dns-socket to avoid [CVE-2021-23386](https://github.com/advisories/GHSA-3wcq-x3mq-6r9p)